### PR TITLE
Allow JMS/Serializer v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Carbon Serialization or JSM Serializer",
     "type": "library",
     "require": {
-        "jms/serializer": "^2.0",
+        "jms/serializer": "^2.0 || ^3.0",
         "nesbot/carbon": "^2.5"
     },
     "license": "GNU General Public License v2.0",


### PR DESCRIPTION
According to the [upgrade guide](https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md#from-2x-to-300) there's no real breaking changes between v2 and v3.